### PR TITLE
Using a colon in the unquoted mapping value

### DIFF
--- a/config/localization/en.yml
+++ b/config/localization/en.yml
@@ -46,7 +46,7 @@ group:
     title: Get your shop ready for payments
     subtitle:
       1: How do you want your customers to pay you?
-      2: Adapt your offer to your market: add the most popular payment methods for your customers!
+      2: "Adapt your offer to your market: add the most popular payment methods for your customers!"
     step:
       1: The payments methods are already available to your customers.
       2: And you can choose to add other payment methods from here!


### PR DESCRIPTION
Avoid error 
vendor\symfony\symfony\src\Symfony\Component\Yaml\Parser.php | ln:509 | msg:Using a colon in the unquoted mapping value "Adapt your offer to your market: add the most popular payment methods for your customers!" in line 49 is deprecated since Symfony 2.8 and will throw a ParseException in 3.0.