### PR TITLE
Check SymfonyContainer is not null prior init

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>welcome</name>
     <displayName><![CDATA[Welcome]]></displayName>
-    <version><![CDATA[3.0.0]]></version>
+    <version><![CDATA[4.0.0]]></version>
     <description><![CDATA[Help the user to create his first product.]]></description>
     <author><![CDATA[PrestaShop]]></author>
     <tab><![CDATA[]]></tab>

--- a/welcome.php
+++ b/welcome.php
@@ -61,7 +61,7 @@ class Welcome extends Module
             'max' => _PS_VERSION_,
         ];
 
-        if (Module::isInstalled($this->name)) {
+        if (Module::isInstalled($this->name) && null !== SymfonyContainer::getInstance()) {
             $this->onBoarding = new OnBoarding(
                 $this->getTranslator(),
                 $this->smarty,

--- a/welcome.php
+++ b/welcome.php
@@ -49,7 +49,7 @@ class Welcome extends Module
     public function __construct()
     {
         $this->name = 'welcome';
-        $this->version = '3.0.0';
+        $this->version = '4.0.0';
         $this->author = 'PrestaShop';
 
         parent::__construct();

--- a/welcome.php
+++ b/welcome.php
@@ -48,6 +48,12 @@ class Welcome extends Module
      */
     public function __construct()
     {
+        // If the symfony container is not available this constructor will fail
+        // This can happen during the upgrade process
+        if (null == SymfonyContainer::getInstance()) {
+            return;
+        }
+
         $this->name = 'welcome';
         $this->version = '4.0.0';
         $this->author = 'PrestaShop';
@@ -61,7 +67,7 @@ class Welcome extends Module
             'max' => _PS_VERSION_,
         ];
 
-        if (Module::isInstalled($this->name) && null !== SymfonyContainer::getInstance()) {
+        if (Module::isInstalled($this->name)) {
             $this->onBoarding = new OnBoarding(
                 $this->getTranslator(),
                 $this->smarty,


### PR DESCRIPTION
When upgrading from `1.7.2.4` --> `1.7.3.0`, we encounter the following issue:

```
[Wed Dec 27 12:40:56.093192 2017] [:error] [pid 384] [client 172.18.0.3:45104] PHP Fatal error:  Call to a member function get() on null in /var/www/html/modules/welcome/welcome.php on line 69, referer: http://ugly-sofa.machine-shuffle.prestashop.net/admin-dev/index.php?controller=adminselfupgrade&token=9def3ee9562a0ca0657429b6cc14d6f9
```
This is caused by the Symfony core not initialized during the upgrade process but requested anyway.