### PR TITLE
Return after init

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>welcome</name>
     <displayName><![CDATA[Welcome]]></displayName>
-    <version><![CDATA[4.0.0]]></version>
+    <version><![CDATA[4.0.1]]></version>
     <description><![CDATA[Help the user to create his first product.]]></description>
     <author><![CDATA[PrestaShop]]></author>
     <tab><![CDATA[]]></tab>

--- a/welcome.php
+++ b/welcome.php
@@ -55,7 +55,7 @@ class Welcome extends Module
         }
 
         $this->name = 'welcome';
-        $this->version = '4.0.0';
+        $this->version = '4.0.1';
         $this->author = 'PrestaShop';
 
         parent::__construct();

--- a/welcome.php
+++ b/welcome.php
@@ -48,12 +48,6 @@ class Welcome extends Module
      */
     public function __construct()
     {
-        // If the symfony container is not available this constructor will fail
-        // This can happen during the upgrade process
-        if (null == SymfonyContainer::getInstance()) {
-            return;
-        }
-
         $this->name = 'welcome';
         $this->version = '4.0.1';
         $this->author = 'PrestaShop';
@@ -66,6 +60,12 @@ class Welcome extends Module
             'min' => '1.7.3.0',
             'max' => _PS_VERSION_,
         ];
+
+        // If the symfony container is not available this constructor will fail
+        // This can happen during the upgrade process
+        if (null == SymfonyContainer::getInstance()) {
+            return;
+        }
 
         if (Module::isInstalled($this->name)) {
             $this->onBoarding = new OnBoarding(


### PR DESCRIPTION
Unfortunately, returning from the first line of the constructor may break the shop if we do not set the mandatory variables first.
This PR moves the test a few lines after.