### PR TITLE
Do not override the link smarty variable

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -60,7 +60,11 @@ jobs:
             - name: Pull PrestaShop files (Tag ${{ matrix.presta-versions }})
               run: docker run -tid --rm -v ps-volume:/var/www/html --name temp-ps prestashop/prestashop:${{ matrix.presta-versions }}
 
+            # Clear previous instance of the module in the PrestaShop volume
+            - name: Clear previous module
+              run: docker exec -t temp-ps rm -rf /var/www/html/modules/welcome
+
             # Run a container for PHPStan, having access to the module content and PrestaShop sources.
             # This tool is outside the composer.json because of the compatibility with PHP 5.6
             - name : Run PHPStan
-              run: docker run --rm --volumes-from temp-ps -v $PWD:/web/module -e _PS_ROOT_DIR_=/var/www/html --workdir=/web/module phpstan/phpstan:0.12 analyse --configuration=/web/module/tests/phpstan/phpstan.neon
+              run: docker run --rm --volumes-from temp-ps -v $PWD:/var/www/html/modules/welcome -e _PS_ROOT_DIR_=/var/www/html --workdir=/var/www/html/modules/welcome phpstan/phpstan:0.12 analyse --configuration=/var/www/html/modules/welcome/tests/phpstan/phpstan.neon

--- a/OnBoarding/OnBoarding.php
+++ b/OnBoarding/OnBoarding.php
@@ -96,14 +96,13 @@ class OnBoarding
     /**
      * Show the OnBoarding content for the nav bar.
      */
-    public function showModuleContentForNavBar($link)
+    public function showModuleContentForNavBar()
     {
         echo $this->getTemplateContent('navbar', [
             'currentStep' => $this->getCurrentStep(),
             'totalSteps' => $this->getTotalSteps(),
             'percent_real' => ($this->getCurrentStep() / $this->getTotalSteps()) * 100,
             'percent_rounded' => round(($this->getCurrentStep() / $this->getTotalSteps()) * 100),
-            'link' => $link->getAdminLink('AdminWelcome'),
         ]);
     }
 
@@ -203,7 +202,7 @@ class OnBoarding
      * @param string $templateName Template name
      * @param array $additionnalParameters Additionnal parameters to inject on the Twig template
      *
-     * @return string|null
+     * @return string
      */
     private function getTemplateContent($templateName, $additionnalParameters = [])
     {

--- a/views/content.tpl
+++ b/views/content.tpl
@@ -40,7 +40,7 @@
   var onBoarding;
 
   $(function(){
-    onBoarding = new OnBoarding({$currentStep}, {$jsonSteps nofilter}, {$isShutDown}, "{$link}", baseAdminDir);
+    onBoarding = new OnBoarding({$currentStep}, {$jsonSteps nofilter}, {$isShutDown}, "{$link->getAdminLink('AdminWelcome')}", baseAdminDir);
 
     {foreach from=$templates item=template}
       onBoarding.addTemplate('{$template['name']}', '{$template['content']}');

--- a/welcome.php
+++ b/welcome.php
@@ -170,7 +170,7 @@ class Welcome extends Module
     public function hookDisplayAdminNavBarBeforeEnd()
     {
         if (!$this->onBoarding->isFinished()) {
-            $this->onBoarding->showModuleContentForNavBar($this->context->link);
+            $this->onBoarding->showModuleContentForNavBar();
         }
     }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | When BO pages are loaded as an iframe in a popin, the hook `displayAdminNavBarBeforeEnd` is not called leading to the smarty variable `$link` not being overrode leading to an object to string conversion error.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/22201
| How to test?  | With a fresh install, in the BO, click on "Later" on the "Welcome to your shop!" popin (**do not click on "Stop the onboarding"**), then go to any order detail and try to edit the customer address. You shouldn't get any error.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
