### PR TITLE
Use master instead of current branch for release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,9 +1,14 @@
-change-template: '- $TITLE (#$NUMBER)'
+branches:
+  - master
+name-template: v$NEXT_PATCH_VERSION
+tag-template: v$NEXT_PATCH_VERSION
+categories:
+  - title: 🚀 Improvements
+    label: enhancement
+  - title: 🐛 Bug Fixes
+    label: bug
+change-template: '- #$NUMBER: $TITLE by @$AUTHOR'
 template: |
-    ## Changelog
+  # Changes
 
-    $CHANGES
-
-    ### Contributors
-
-    $CONTRIBUTORS
+  $CHANGES


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Use only the master branch.
| Type?         | bug fix

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
