### PR TITLE
Make sure PS_ADMIN_DIR exists before using the OnBoarding

### DIFF
--- a/welcome.php
+++ b/welcome.php
@@ -63,9 +63,10 @@ class Welcome extends Module
             'max' => _PS_VERSION_,
         ];
 
-        // If the symfony container is not available this constructor will fail
+        // If the symfony container is not available or if we are not in the admin directory
+        // this constructor will fail.
         // This can happen during the upgrade process
-        if (null == SymfonyContainer::getInstance()) {
+        if (null == SymfonyContainer::getInstance() || !defined('_PS_ADMIN_DIR_')) {
             return;
         }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | The constructor is instancing the OnBoarding class, which is using the Configuration class, which is using the `_PS_ADMIN_DIR_` constant (https://github.com/PrestaShop/welcome/blob/dev/OnBoarding/Configuration.php#L281). As it has been done for the Symfony container, make sure the constant exists.
| Type?         | bug fix
| How to test?  | I don't know how to properly test it, however, it's needed for the open source split.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
