### PR TITLE
Fix step1 of step 3/6 not showing in 1.7.8.x

### DIFF
--- a/OnBoarding/Configuration.php
+++ b/OnBoarding/Configuration.php
@@ -141,7 +141,7 @@ class Configuration
                                     'savepoint',
                                 ],
                                 'page' => $contextLink->getAdminLink('AdminThemes'),
-                                'selector' => '#form_shop_logos_header_logo',
+                                'selector' => '#form_shop_logos_header_logo, #form_header_logo',
                                 'position' => 'right',
                             ],
                             [


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | in 1.7.8.x the selector of the header logo form changed, this PR adds the new selector so it can be shown.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes partially PrestaShop/Prestashop#24463
| How to test?  | See #24463, step1 of step 3/6 should be shown

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
