### PR TITLE
Release v6.0.8

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>welcome</name>
     <displayName><![CDATA[Welcome]]></displayName>
-    <version><![CDATA[6.0.7]]></version>
+    <version><![CDATA[6.0.8]]></version>
     <description><![CDATA[Help the user to create his first product.]]></description>
     <author><![CDATA[PrestaShop]]></author>
     <tab><![CDATA[]]></tab>

--- a/welcome.php
+++ b/welcome.php
@@ -57,7 +57,7 @@ class Welcome extends Module
     public function __construct()
     {
         $this->name = 'welcome';
-        $this->version = '6.0.7';
+        $this->version = '6.0.8';
         $this->author = 'PrestaShop';
 
         parent::__construct();


### PR DESCRIPTION
The issue in https://github.com/PrestaShop/PrestaShop/issues/29867 is that after upgrading to 8.0.0, the module welcome doesn't have its own autoloader (and cannot rely on PrestaShop's autoloader because the module has been removed from composer.json). By releasing a new version of it, this will force the upgrade of the module during the upgrade of PrestaShop and the module will then contain its own autoloader.
We usually merge dev into master but here dev contains other changes than just a version bump.